### PR TITLE
[add]: Can obtain multiple values from one request

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,13 @@
 [![Docker Build Statu](https://img.shields.io/docker/build/tolleiv/json-exporter.svg)](https://hub.docker.com/r/tolleiv/json-exporter/)
 
 This Prometheus exporter operates similar to the Blackbox exporters. It downloads a JSON file and provides a numerical gauge value from within that file.
-Which value to pick is defined through JsonPath.
+Which values to pick is defined through jsonpath.[METRIC_NAME_M]=[JSON PATH_N].
 
 ## Parameters
 
  - `target`: URL / Json-file to download
- - `jsonpath`: the field name to read the value from, this follows the syntax provided by [oliveagle/jsonpath](https://github.com/oliveagle/jsonpath)
+ - `jsonpath.[METRIC_NAME_1]=[JSON PATH_1]`: the field name to read the value from, this follows the syntax provided by [oliveagle/jsonpath](https://github.com/oliveagle/jsonpath)
+ - `jsonpath.[METRIC_NAME_N]=[JSON PATH_N]`: the field name to read the value from, this follows the syntax provided by [oliveagle/jsonpath](https://github.com/oliveagle/jsonpath)
 
 ## Docker usage
 
@@ -17,7 +18,7 @@ Which value to pick is defined through JsonPath.
    
 The related metrics can then be found under:
    
-    http://localhost:9116/probe?target=http://validate.jsontest.com/?json=%7B%22key%22:%22value%22%7D&jsonpath=$.parse_time_nanoseconds
+    http://localhost:9116/probe?target=http://validate.jsontest.com/?json=%7B%22key%22:%22value%22%7D&jsonpath.nanoseconds=$.parse_time_nanoseconds&jsonpath.size=$.size
 
 ## Prometheus Configuration
 
@@ -30,7 +31,8 @@ scrape_configs:
   - job_name: 'json'
     metrics_path: /probe
     params:
-      jsonpath: [$.parse_time_nanoseconds] # Look for the nanoseconds field
+      - jsonpath.nanoseconds: [$.parse_time_nanoseconds] # Look for the nanoseconds field
+      - jsonpath.size: [$.size]
     static_configs:
       - targets:
         - http://validate.jsontest.com/?json=%7B%22key%22:%22value%22%7D
@@ -41,9 +43,6 @@ scrape_configs:
         target_label: instance
       - target_label: __address__
         replacement: 127.0.0.1:9116  # Json exporter.
-    metric_relabel_configs:
-      - source_labels: value
-        target_label: parse_time
 
 ```
 

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"log"
 	"net/http"
+	"strings"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/client_golang/prometheus"
@@ -34,15 +35,25 @@ func main() {
 
 func probeHandler(w http.ResponseWriter, r *http.Request) {
 
-	params := r.URL.Query()
-	target := params.Get("target")
+	get_params := r.URL.Query()
+	a_param := make(map[string]string)
+
+	// log.Printf("get_params: %v", get_params)
+	for k, v := range get_params {
+		log.Printf("key[%s] value %s\n", k, v)
+		if( strings.Contains(k , "jsonpath.") ) {
+			a_param[strings.Replace(k,"jsonpath.","",-1)] = get_params.Get(k)
+		}
+	}
+	// log.Printf("a_target: %v", a_target)
+
+	target := get_params.Get("target")
 	if target == "" {
 		http.Error(w, "Target parameter is missing", 400)
 		return
 	}
-	lookuppath := params.Get("jsonpath")
-	if target == "" {
-		http.Error(w, "The JsonPath to lookup", 400)
+	if (len(a_param) == 0){
+		http.Error(w, "No JsonPath to lookup", 400)
 		return
 	}
 	probeSuccessGauge := prometheus.NewGauge(prometheus.GaugeOpts{
@@ -53,16 +64,10 @@ func probeHandler(w http.ResponseWriter, r *http.Request) {
 		Name: "probe_duration_seconds",
 		Help: "Returns how long the probe took to complete in seconds",
 	})
-	valueGauge := prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Name:	"value",
-			Help:	"Retrieved value",
-		},
-	)
+
 	registry := prometheus.NewRegistry()
 	registry.MustRegister(probeSuccessGauge)
 	registry.MustRegister(probeDurationGauge)
-	registry.MustRegister(valueGauge)
 
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
@@ -82,19 +87,27 @@ func probeHandler(w http.ResponseWriter, r *http.Request) {
 
 		var json_data interface{}
 		json.Unmarshal([]byte(bytes), &json_data)
-		res, err := jsonpath.JsonPathLookup(json_data, lookuppath)
-		if err != nil {
-			http.Error(w, "Jsonpath not found", http.StatusNotFound)
-			return
-		}
-		log.Printf("Found value %v", res)
-		number, ok := res.(float64)
-		if !ok {
-			http.Error(w, "Values could not be parsed to Float64", http.StatusInternalServerError)
-			return
+
+	   for metric_name, json_path := range a_param {
+			res, err := jsonpath.JsonPathLookup(json_data, json_path)
+			if err != nil {
+				http.Error(w, "Jsonpath not found", http.StatusNotFound)
+				return
+			}
+			log.Printf("Found value %v for path %s", res, json_path)
+			number, ok := res.(float64)
+			if !ok {
+				http.Error(w, "Values could not be parsed to Float64", http.StatusInternalServerError)
+				return
+			}
+			valueGauge := prometheus.NewGauge(prometheus.GaugeOpts{
+				Name:	metric_name,
+				Help:	"Retrieved value",
+			})
+			registry.MustRegister(valueGauge)
+			valueGauge.Set(number)
 		}
 		probeSuccessGauge.Set(1)
-		valueGauge.Set(number)
 	}
 
 	h := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})


### PR DESCRIPTION
It can obtain multiple values from one request. Sometimes in the json there are more than one value to get so this change let us to it.

The target now looks this way:
http://localhost:9116/probe?target=http://validate.jsontest.com/?json=%7B%22key%22:%22value%22%7D&jsonpath.nanoseconds=$.parse_time_nanoseconds&jsonpath.size=$.size

We must provide:
- target, as usual.
- jsonpath.[prometheus_metric_name]=[json_path]

The last param can be more than one time and will create as many metrics as we define.

E.g:

```
nagraops@debian-nagraops:~/repo/monitoring/json-exporter$ curl "http://localhost:9116/probe?target=http://validate.jsontest.com/?json=%7B%22key%22:%22value%22%7D&jsonpath.parse_time_nanoseconds=$.parse_time_nanoseconds&jsonpath.size=$.size"
# HELP parse_time_nanoseconds Retrieved value
# TYPE parse_time_nanoseconds gauge
parse_time_nanoseconds 41996
# HELP probe_duration_seconds Returns how long the probe took to complete in seconds
# TYPE probe_duration_seconds gauge
probe_duration_seconds 0
# HELP probe_success Displays whether or not the probe was a success
# TYPE probe_success gauge
probe_success 1
# HELP size Retrieved value
# TYPE size gauge
size 1
```
